### PR TITLE
Inseperable prep

### DIFF
--- a/tests/utils/test_heb.py
+++ b/tests/utils/test_heb.py
@@ -3,7 +3,7 @@
 import pytest
 from hamcrest import assert_that, equal_to
 
-from bm_tools.utils.heb import parse_definite_article
+from bm_tools.utils.heb import parse_definite_article, parse_inseparable_prepositions
 
 
 @pytest.mark.parametrize(
@@ -23,4 +23,37 @@ def test_parse_definite_article(raw: str, word: str, definite_article: bool) -> 
     actual_word, actual_definite_article = parse_definite_article(raw=raw)
 
     assert_that(actual_definite_article, equal_to(definite_article))
+    assert_that(list(actual_word), equal_to(list(word)))
+
+
+@pytest.mark.parametrize(
+    ("raw", "word", "preposition", "definite_article"),
+    [
+        ("", "", None, False),
+        ("בִּרְקִיעַ", "רְקִיעַ", "ב", False),
+        ("לְאֹתֹת", "אֹתֹת", "ל", False),
+        # Before Yod Sheva
+        ("בִּימֵי", "יְמֵי", "ב", False),
+        # Before Composite/hataf Sheva, point with the corresponding short vowel
+        ("לַעֲבֹד", "עֲבֹד", "ל", False),
+        ("בַּעֲדוֹ", "עֲדוֹ", "ב", False),
+        ("כַּאֲשֶׁר", "אֲשֶׁר", "כ", False),
+        ("מִתַּחַת", "תַחַת", "מ", False),
+        ("מֵעַל", "עַל", "מ", False),
+        ("מֵהָעוֹף", "עוֹף", "מ", True),
+    ],
+)
+def test_parse_inseparable_prepositions(
+    raw: str,
+    word: str,
+    preposition: str,
+    definite_article: bool,  # noqa: FBT001
+) -> None:
+    """Test the definite article is correctly parsed."""
+    actual_word, actual_preposition, actual_definite_article = (
+        parse_inseparable_prepositions(raw=raw)
+    )
+
+    assert_that(actual_definite_article, equal_to(definite_article))
+    assert_that(actual_preposition, equal_to(preposition))
     assert_that(list(actual_word), equal_to(list(word)))


### PR DESCRIPTION
The largest improvement here is the inseparable preposition parsing. I've added in test cases as this is now getting more complicated and to go much further without building up corresponding unit tests would likely be fraught with error.

On the whole, this does seem to be a large step forward, there are some regressions. This is because the rules are now more explicit and so conservative in nature. This is a good thing as there are significantly fewer false positives.

There are some cases where for example `BARA'` (he created) is now incorrectly being parsed as `BA` (in the) - `RA'` (Evil). As the root word is being split. This is quite interesting, and it's the kind of thing that I'm curious to see as it potentially opens up alternative ways of breaking down words - in this case clearly incorrectly.

At the moment I'm going to leave it as it is and see how common this issue is when a purely mechanical parsing approach is applied, partly out of curiosity. It raises an interesting point, there are sometimes multiple ways of breaking words down, and as Humans we can intuitively reject options and come to the "right" solution. However there may be times where we have been conditioned to solution out of tradition that may not be correct. So it might be nice to be able to inspect the different options and review them.

There are several ways of dealing with this problem that I can think of right now. Have a lookup table of special cases (ideally not), lookup the resulting root in a table of valid roots (wouldn't help in this case?), or present all options for manual review. That last option should be possible at the very least in some kind of debug mode.